### PR TITLE
Ensure sequential indicator checks and add signal tests

### DIFF
--- a/bottradingv44.py
+++ b/bottradingv44.py
@@ -323,65 +323,65 @@ class ModuloAnalisisSeñales:
                 confidence = 0.75
             
             # 2. Estocástico - Cruces en zonas extremas
-            elif not signal_direction:
+            if signal_direction is None:
                 if current['stoch_k'] < TradingConfig.STOCH_OVERSOLD:
                     if previous['stoch_k'] < previous['stoch_d'] and current['stoch_k'] > current['stoch_d']:
                         signal_direction = "BUY"
                         signal_source = SignalSource.STOCHASTIC
                         signal_description = f"Cruce alcista del Estocástico en sobreventa"
                         confidence = 0.8
-                        
+
                 elif current['stoch_k'] > TradingConfig.STOCH_OVERBOUGHT:
                     if previous['stoch_k'] > previous['stoch_d'] and current['stoch_k'] < current['stoch_d']:
                         signal_direction = "SELL"
                         signal_source = SignalSource.STOCHASTIC
                         signal_description = f"Cruce bajista del Estocástico en sobrecompra"
                         confidence = 0.8
-            
+
             # 3. MACD - Cruces con línea de señal
-            elif not signal_direction:
+            if signal_direction is None:
                 if previous['macd'] < previous['macd_signal'] and current['macd'] > current['macd_signal']:
                     signal_direction = "BUY"
                     signal_source = SignalSource.MACD
                     signal_description = f"Cruce alcista del MACD"
                     confidence = 0.75
-                    
+
                 elif previous['macd'] > previous['macd_signal'] and current['macd'] < current['macd_signal']:
                     signal_direction = "SELL"
                     signal_source = SignalSource.MACD
                     signal_description = f"Cruce bajista del MACD"
                     confidence = 0.75
-            
+
             # 4. Cruce de EMAs
-            elif not signal_direction:
+            if signal_direction is None:
                 if previous['ema_fast'] < previous['ema_slow'] and current['ema_fast'] > current['ema_slow']:
                     signal_direction = "BUY"
                     signal_source = SignalSource.EMA_CROSS
                     signal_description = f"EMA{TradingConfig.EMA_FAST} cruzó por encima de EMA{TradingConfig.EMA_SLOW}"
                     confidence = 0.7
-                    
+
                 elif previous['ema_fast'] > previous['ema_slow'] and current['ema_fast'] < current['ema_slow']:
                     signal_direction = "SELL"
                     signal_source = SignalSource.EMA_CROSS
                     signal_description = f"EMA{TradingConfig.EMA_FAST} cruzó por debajo de EMA{TradingConfig.EMA_SLOW}"
                     confidence = 0.7
-            
+
             # 5. Bandas de Bollinger - Breakouts
-            elif not signal_direction:
+            if signal_direction is None:
                 if current['close'] > current['bb_upper'] and previous['close'] <= previous['bb_upper']:
                     signal_direction = "BUY"
                     signal_source = SignalSource.BOLLINGER
                     signal_description = f"Ruptura alcista de Banda de Bollinger superior"
                     confidence = 0.65
-                    
+
                 elif current['close'] < current['bb_lower'] and previous['close'] >= previous['bb_lower']:
                     signal_direction = "SELL"
                     signal_source = SignalSource.BOLLINGER
                     signal_description = f"Ruptura bajista de Banda de Bollinger inferior"
                     confidence = 0.65
-            
+
             # 6. Patrones de Velas
-            if not signal_direction:
+            if signal_direction is None:
                 patterns = self.detect_candlestick_patterns(df)
                 
                 # Patrones alcistas

--- a/tests/test_signal_evaluation.py
+++ b/tests/test_signal_evaluation.py
@@ -1,0 +1,188 @@
+from datetime import datetime, timedelta
+from pathlib import Path
+import sys
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+try:  # pragma: no cover - entorno de pruebas sin dependencias reales
+    import MetaTrader5  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - utilizado en pruebas
+    mt5_stub_module = types.ModuleType("MetaTrader5")
+    mt5_stub_module.TIMEFRAME_M5 = 0
+    mt5_stub_module.ORDER_TYPE_BUY = 0
+    mt5_stub_module.ORDER_TYPE_SELL = 1
+    mt5_stub_module.TRADE_ACTION_SLTP = 2
+    mt5_stub_module.TRADE_ACTION_DEAL = 3
+    mt5_stub_module.TRADE_RETCODE_DONE = 10009
+    mt5_stub_module.SYMBOL_TRADE_MODE_FULL = 0
+
+    def _return_none(*args, **kwargs):
+        return None
+
+    def _return_false(*args, **kwargs):
+        return False
+
+    mt5_stub_module.copy_rates_from_pos = _return_none
+    mt5_stub_module.symbol_info = _return_none
+    mt5_stub_module.account_info = _return_none
+    mt5_stub_module.symbol_info_tick = _return_none
+    mt5_stub_module.order_send = _return_none
+    mt5_stub_module.positions_get = _return_none
+    mt5_stub_module.positions_total = _return_none
+    mt5_stub_module.initialize = lambda: True
+    mt5_stub_module.login = lambda *args, **kwargs: True
+    mt5_stub_module.shutdown = _return_none
+    mt5_stub_module.symbols_get = _return_none
+
+    sys.modules["MetaTrader5"] = mt5_stub_module
+
+try:  # pragma: no cover - entorno de pruebas sin dependencias reales
+    import telegram  # type: ignore  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - utilizado en pruebas
+    telegram_module = types.ModuleType("telegram")
+
+    class _TelegramDummy:  # pragma: no cover - clase auxiliar
+        pass
+
+    telegram_module.Bot = _TelegramDummy
+    telegram_module.Update = _TelegramDummy
+    sys.modules["telegram"] = telegram_module
+
+    telegram_ext_module = types.ModuleType("telegram.ext")
+    telegram_ext_module.Application = _TelegramDummy
+    telegram_ext_module.CommandHandler = _TelegramDummy
+
+    class _TelegramContextTypes:  # pragma: no cover - clase auxiliar
+        DEFAULT_TYPE = object()
+
+    telegram_ext_module.ContextTypes = _TelegramContextTypes
+    sys.modules["telegram.ext"] = telegram_ext_module
+
+import pandas as pd
+
+import bottradingv44 as bot
+
+
+class Dummy:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+class MT5Stub:
+    def __init__(self):
+        self._symbol_info = Dummy(
+            point=0.01,
+            spread=2,
+            trade_tick_value=1.0,
+            volume_step=0.01,
+            digits=5,
+            trade_stops_level=0,
+        )
+        self._account_info = Dummy(balance=10_000.0)
+
+    def symbol_info(self, symbol):
+        return self._symbol_info
+
+    def account_info(self):
+        return self._account_info
+
+
+def build_indicator_dataframe(prev_updates=None, curr_updates=None, size=60):
+    base_row = {
+        "open": 100.0,
+        "high": 101.0,
+        "low": 99.0,
+        "close": 100.0,
+        "tick_volume": 1000,
+        "rsi": 50.0,
+        "stoch_k": 50.0,
+        "stoch_d": 50.0,
+        "macd": 0.0,
+        "macd_signal": 0.0,
+        "macd_hist": 0.0,
+        "ema_fast": 100.0,
+        "ema_slow": 100.0,
+        "bb_upper": 102.0,
+        "bb_lower": 98.0,
+        "atr": 1.0,
+    }
+
+    rows = [base_row.copy() for _ in range(size - 2)]
+
+    previous_row = base_row.copy()
+    if prev_updates:
+        previous_row.update(prev_updates)
+    rows.append(previous_row)
+
+    current_row = base_row.copy()
+    if curr_updates:
+        current_row.update(curr_updates)
+    rows.append(current_row)
+
+    index = pd.date_range(datetime.now() - timedelta(minutes=size - 1), periods=size, freq="min")
+    df = pd.DataFrame(rows, index=index)
+    return df
+
+
+class TestModulo(bot.ModuloAnalisisSeñales):
+    def __init__(self, df):
+        super().__init__(mt5_conn=None)
+        self._df = df
+
+    def fetch_rates(self, symbol, timeframe, count):
+        return self._df
+
+    def calculate_all_indicators(self, df):
+        return self._df
+
+
+def setup_mt5_stub(monkeypatch):
+    stub = MT5Stub()
+    monkeypatch.setattr(bot, "mt5", stub)
+    return stub
+
+
+def test_macd_signal_is_reached(monkeypatch):
+    setup_mt5_stub(monkeypatch)
+    df = build_indicator_dataframe(
+        prev_updates={"macd": -0.1, "macd_signal": 0.1},
+        curr_updates={"macd": 0.2, "macd_signal": 0.0},
+    )
+
+    modulo = TestModulo(df)
+    signal = modulo.check_all_signals("EURUSD")
+
+    assert signal is not None
+    assert signal.source == bot.SignalSource.MACD
+    assert signal.direction == "BUY"
+
+
+def test_ema_cross_signal_is_reached(monkeypatch):
+    setup_mt5_stub(monkeypatch)
+    df = build_indicator_dataframe(
+        prev_updates={"ema_fast": 99.0, "ema_slow": 100.0, "macd": 0.05, "macd_signal": 0.05},
+        curr_updates={"ema_fast": 101.0, "ema_slow": 100.0, "macd": 0.05, "macd_signal": 0.05},
+    )
+
+    modulo = TestModulo(df)
+    signal = modulo.check_all_signals("EURUSD")
+
+    assert signal is not None
+    assert signal.source == bot.SignalSource.EMA_CROSS
+    assert signal.direction == "BUY"
+
+
+def test_bollinger_signal_is_reached(monkeypatch):
+    setup_mt5_stub(monkeypatch)
+    df = build_indicator_dataframe(
+        prev_updates={"close": 100.0, "bb_upper": 102.0},
+        curr_updates={"close": 103.0, "bb_upper": 102.0, "bb_lower": 98.0, "ema_fast": 100.0, "ema_slow": 100.0},
+    )
+
+    modulo = TestModulo(df)
+    signal = modulo.check_all_signals("EURUSD")
+
+    assert signal is not None
+    assert signal.source == bot.SignalSource.BOLLINGER
+    assert signal.direction == "BUY"


### PR DESCRIPTION
## Summary
- ensure the stochastic, MACD, EMA and Bollinger checks only execute when no prior signal exists so later indicators can trigger
- add regression-style tests with lightweight MetaTrader5/Telegram stubs to validate MACD, EMA and Bollinger signals are reached

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2be77cb0c832f9cebb043a07c4208